### PR TITLE
Travis CI integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: python
+
+python:
+    - 2.7
+
+install:
+    - pip install -r requirements.txt
+
+script:
+    - python test_controller.py
+    - python test_manager.py


### PR DESCRIPTION
Add **Travis CI** integration, for automatic test execution with each commit in `master` or pull request.

**Note**: Travis support has to be enabled in https://travis-ci.org/.